### PR TITLE
Modification that enables unsafe cookies to be used from outside

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function (options) {
   var forcedCookieOptions = {httpOnly: true, secure: true, signed: true};
   // forcedCookieOptions will overwrite same keys in cookieOptions.
   cookieOptions = _.extend({path: '/', maxAge: null, httpOnly: true},
-    _.defaults(forcedCookieOptions, cookieOptions));
+    _.defaults(cookieOptions, forcedCookieOptions));
 
   return function parseExpressCookieSession(req, res, next) {
     // Expect cookieParser to set req.secret before this middleware.


### PR DESCRIPTION
The usage is as follows:

app.use(parseExpressCookieSession({
  key: 'SECRET_KEY', /* more params go here */, cookie: {maxAge: 3600000, secure: false}
}));

If the user wants to use SSL, just set 'secure' to "true"